### PR TITLE
Fix forcing use of Roboto for API<21

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,1 @@
-AppCompatExtension
+AppCompat-Extension-Library

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
+    <option name="DEFAULT_COMPILER" value="Javac" />
     <resourceExtensions />
     <wildcardResourcePatterns>
       <entry name="!?*.java" />
@@ -11,7 +12,6 @@
       <entry name="!?*.flex" />
       <entry name="!?*.kt" />
       <entry name="!?*.clj" />
-      <entry name="!?*.aj" />
     </wildcardResourcePatterns>
     <annotationProcessing>
       <profile default="true" name="Default" enabled="false">

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -3,8 +3,9 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="distributionType" value="LOCAL" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleHome" value="C:\Program Files\Android\Android Studio\gradle\gradle-2.10" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/AppCompatExtension.iml" filepath="$PROJECT_DIR$/AppCompatExtension.iml" />
+      <module fileurl="file://$PROJECT_DIR$/AppCompat-Extension-Library.iml" filepath="$PROJECT_DIR$/AppCompat-Extension-Library.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
       <module fileurl="file://$PROJECT_DIR$/appcompat-extension/appcompat-extension.iml" filepath="$PROJECT_DIR$/appcompat-extension/appcompat-extension.iml" />
     </modules>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/AppCompat-Extension-Library.iml
+++ b/AppCompat-Extension-Library.iml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id="AppCompat-Extension-Library" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="java-gradle" name="Java-Gradle">
+      <configuration>
+        <option name="BUILD_FOLDER_PATH" value="$MODULE_DIR$/build" />
+        <option name="BUILDABLE" value="false" />
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.gradle" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ The `TypefaceCompat` is a utility for supporting the newest [Typography](https:/
 ##### Main features:
 * Easily setup with one line of code in your `Activity`.
 * Use one of the `TextAppearance.AppCompat.xxx` styles or use your own styles!
-* Automatically sets textSize, textColor and lineSpacing for the `TextAppearance.AppCompat.xxx` styles and loads the new Roboto typeface on pre-Lollipop devices using a cache!
+* Automatically sets textSize, textColor and fontFamiliy for the `TextAppearance.AppCompat.xxx` styles and loads the new Roboto typeface on pre-Lollipop devices using a cache!
 
 ##### Basic setup:
 In your `Activity` (for ease of use in your `BaseActivity`, if you have one) add the following line *before* `super.onCreate()`:

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ final IndeterminateProgressDrawable drawable = new IndeterminateProgressDrawable
 *For the full documentation and customization options head over to the [Delightful Detail Drawables wiki](https://github.com/TR4Android/AppCompat-Extension-Library/wiki/Delightful-Detail-Drawables).*
 
 ## TypefaceCompat
-The `TypefaceCompat` is a utility for supporting the newest [Typography](https://www.google.com/design/spec/style/typography.html). It automatically sets the text size, color, line spacing *and typeface* for the styles specified in the guidelines.
+The `TypefaceCompat` is a utility for supporting the newest [Typography](https://www.google.com/design/spec/style/typography.html). It automatically sets the text size, color *and typeface* for the styles specified in the guidelines.
 
 ##### Main features:
 * Easily setup with one line of code in your `Activity`.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ public class SampleActivity extends AppCompatActivity {
 ```
 Then use one of the `TextAppearance.AppCompat.xxx` styles via `android:textAppearance="@style/TextAppearance.AppCompat.xxx"` on your `TextView`s.
 
+To achieve the correct line height use one of the predefined `line_spacing_extra_xxx` values via `android:lineSpacingExtra="@dimen/line_spacing_extra_xxx"` on your `TextView`.
+
 *For the full documentation and customization options head over to the [TypefaceCompat wiki](https://github.com/TR4Android/AppCompat-Extension-Library/wiki/TypefaceCompat).*
 
 ## License

--- a/app/app.iml
+++ b/app/app.iml
@@ -61,13 +61,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
@@ -75,8 +68,16 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />

--- a/app/app.iml
+++ b/app/app.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":app" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="AppCompatExtension" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":app" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="AppCompat-Extension-Library" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>
@@ -61,13 +61,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
@@ -75,9 +68,15 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
@@ -91,7 +90,6 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/reload-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/restart-dex" />

--- a/appcompat-extension/src/main/java/com/tr4android/support/extension/typeface/TypefaceCompat.java
+++ b/appcompat-extension/src/main/java/com/tr4android/support/extension/typeface/TypefaceCompat.java
@@ -33,7 +33,7 @@ public class TypefaceCompat {
     private static final LruCache<String, Typeface> TYPEFACE_CACHE = new LruCache<>(TYPEFACE_CACHE_MAX_SIZE);
 
     private static final String SYSTEM_ROBOTO_REGULAR_FILE_PATH = Environment.getRootDirectory() + "/fonts/Roboto-Regular.ttf";
-    private static boolean isRobotoDefaultSansSerifTypeface = true;
+    private static boolean isUsingDefaultFont = true; // boolean indicating whether user wants the device to use its default font or not
 
     static {
         FONT_FAMILY_FILE_PREFIX.put("sans-serif", "Roboto-");
@@ -44,10 +44,10 @@ public class TypefaceCompat {
         FONT_FAMILY_FILE_PREFIX.put("sans-serif-black", "Roboto-Black");
         FONT_FAMILY_FILE_PREFIX.put("sans-serif-condensed-light", "RobotoCondensed-Light");
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR1) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
             Typeface roboto = Typeface.createFromFile(SYSTEM_ROBOTO_REGULAR_FILE_PATH);
             if (roboto != null) {
-                isRobotoDefaultSansSerifTypeface = TypefaceUtils.sameAs(roboto, Typeface.SANS_SERIF);
+                isUsingDefaultFont = TypefaceUtils.sameAs(roboto, Typeface.SANS_SERIF);
             }
         }
     }
@@ -93,6 +93,6 @@ public class TypefaceCompat {
     }
 
     public static boolean isSupported(String familyName) {
-        return FONT_FAMILY_FILE_PREFIX.containsKey(familyName) && isRobotoDefaultSansSerifTypeface && Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP;
+        return FONT_FAMILY_FILE_PREFIX.containsKey(familyName) && isUsingDefaultFont && Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP;
     }
 }

--- a/appcompat-extension/src/main/java/com/tr4android/support/extension/typeface/TypefaceCompat.java
+++ b/appcompat-extension/src/main/java/com/tr4android/support/extension/typeface/TypefaceCompat.java
@@ -19,6 +19,7 @@ package com.tr4android.support.extension.typeface;
 import android.content.Context;
 import android.graphics.Typeface;
 import android.os.Build;
+import android.os.Environment;
 import android.support.v4.util.LruCache;
 
 import java.util.HashMap;
@@ -31,6 +32,9 @@ public class TypefaceCompat {
     private static final int TYPEFACE_CACHE_MAX_SIZE = 8;
     private static final LruCache<String, Typeface> TYPEFACE_CACHE = new LruCache<>(TYPEFACE_CACHE_MAX_SIZE);
 
+    private static final String SYSTEM_ROBOTO_REGULAR_FILE_PATH = Environment.getRootDirectory() + "/fonts/Roboto-Regular.ttf";
+    private static boolean isRobotoDefaultSansSerifTypeface = true;
+
     static {
         FONT_FAMILY_FILE_PREFIX.put("sans-serif", "Roboto-");
         FONT_FAMILY_FILE_PREFIX.put("sans-serif-light", "Roboto-Light");
@@ -39,6 +43,13 @@ public class TypefaceCompat {
         FONT_FAMILY_FILE_PREFIX.put("sans-serif-medium", "Roboto-Medium");
         FONT_FAMILY_FILE_PREFIX.put("sans-serif-black", "Roboto-Black");
         FONT_FAMILY_FILE_PREFIX.put("sans-serif-condensed-light", "RobotoCondensed-Light");
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR1) {
+            Typeface roboto = Typeface.createFromFile(SYSTEM_ROBOTO_REGULAR_FILE_PATH);
+            if (roboto != null) {
+                isRobotoDefaultSansSerifTypeface = TypefaceUtils.sameAs(roboto, Typeface.SANS_SERIF);
+            }
+        }
     }
 
     public static Typeface create(Context ctx, String familyName, int style) {
@@ -82,6 +93,6 @@ public class TypefaceCompat {
     }
 
     public static boolean isSupported(String familyName) {
-        return FONT_FAMILY_FILE_PREFIX.containsKey(familyName) && Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP;
+        return FONT_FAMILY_FILE_PREFIX.containsKey(familyName) && isRobotoDefaultSansSerifTypeface && Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP;
     }
 }

--- a/appcompat-extension/src/main/java/com/tr4android/support/extension/typeface/TypefaceUtils.java
+++ b/appcompat-extension/src/main/java/com/tr4android/support/extension/typeface/TypefaceUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2015 fountaingeyser
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tr4android.support.extension.typeface;
+
+import android.annotation.TargetApi;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.graphics.Typeface;
+import android.os.Build;
+
+public class TypefaceUtils {
+    private static final String TEXT = "abcdefghijklmnopqrstuvwxyz";
+
+    /**
+     * Returns true if all letters of the English alphabet of the typefaces are the same.
+     */
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB_MR1)
+    public static boolean sameAs(Typeface typeface1, Typeface typeface2){
+        // Check if one of the typefaces is null
+        if(typeface1 == null){
+            return typeface2 == null;
+        } else if(typeface2 == null){
+            return false; //result of typeface1 == null
+        }
+
+        // Check if the letters of the English alphabet of the typefaces are the same
+        Paint paint1 = new Paint();
+        paint1.setTypeface(typeface1);
+        Rect bounds1 = new Rect();
+        paint1.getTextBounds(TEXT, 0, TEXT.length(), bounds1);
+        Bitmap bitmap1 = Bitmap.createBitmap(bounds1.width(), bounds1.height(), Bitmap.Config.ALPHA_8);
+        Canvas canvas1 = new Canvas(bitmap1);
+        canvas1.drawText(TEXT, 0, 0, paint1);
+
+        Paint paint2 = new Paint();
+        paint2.setTypeface(typeface2);
+        Rect bounds2 = new Rect();
+        paint2.getTextBounds(TEXT, 0, TEXT.length(), bounds2);
+        Bitmap bitmap2 = Bitmap.createBitmap(bounds2.width(), bounds2.height(), Bitmap.Config.ALPHA_8);
+        Canvas canvas2 = new Canvas(bitmap2);
+        canvas2.drawText(TEXT, 0, 0, paint2);
+
+        return bitmap1.sameAs(bitmap2);
+    }
+}

--- a/appcompat-extension/src/main/java/com/tr4android/support/extension/typeface/TypefaceUtils.java
+++ b/appcompat-extension/src/main/java/com/tr4android/support/extension/typeface/TypefaceUtils.java
@@ -31,30 +31,28 @@ public class TypefaceUtils {
      * Returns true if all letters of the English alphabet of the typefaces are the same.
      */
     @TargetApi(Build.VERSION_CODES.HONEYCOMB_MR1)
-    public static boolean sameAs(Typeface typeface1, Typeface typeface2){
-        // Check if one of the typefaces is null
-        if(typeface1 == null){
+    public static boolean sameAs(Typeface typeface1, Typeface typeface2) {
+        // Handle null as param.
+        if (typeface1 == null) {
             return typeface2 == null;
-        } else if(typeface2 == null){
+        } else if (typeface2 == null) {
             return false; //result of typeface1 == null
         }
 
-        // Check if the letters of the English alphabet of the typefaces are the same
-        Paint paint1 = new Paint();
-        paint1.setTypeface(typeface1);
-        Rect bounds1 = new Rect();
-        paint1.getTextBounds(TEXT, 0, TEXT.length(), bounds1);
-        Bitmap bitmap1 = Bitmap.createBitmap(bounds1.width(), bounds1.height(), Bitmap.Config.ALPHA_8);
-        Canvas canvas1 = new Canvas(bitmap1);
-        canvas1.drawText(TEXT, 0, 0, paint1);
+        // Check if the letters of the English alphabet of the typefaces are the same.
+        Paint paint = new Paint();
+        paint.setTypeface(typeface1);
+        Rect bounds = new Rect();
+        paint.getTextBounds(TEXT, 0, TEXT.length(), bounds);
+        Bitmap bitmap1 = Bitmap.createBitmap(bounds.width(), bounds.height(), Bitmap.Config.ALPHA_8);
+        Canvas canvas = new Canvas(bitmap1);
+        canvas.drawText(TEXT, 0, 0, paint);
 
-        Paint paint2 = new Paint();
-        paint2.setTypeface(typeface2);
-        Rect bounds2 = new Rect();
-        paint2.getTextBounds(TEXT, 0, TEXT.length(), bounds2);
-        Bitmap bitmap2 = Bitmap.createBitmap(bounds2.width(), bounds2.height(), Bitmap.Config.ALPHA_8);
-        Canvas canvas2 = new Canvas(bitmap2);
-        canvas2.drawText(TEXT, 0, 0, paint2);
+        paint.setTypeface(typeface2);
+        paint.getTextBounds(TEXT, 0, TEXT.length(), bounds);
+        Bitmap bitmap2 = Bitmap.createBitmap(bounds.width(), bounds.height(), Bitmap.Config.ALPHA_8);
+        canvas.setBitmap(bitmap2);
+        canvas.drawText(TEXT, 0, 0, paint);
 
         return bitmap1.sameAs(bitmap2);
     }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta6'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta7'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
In case the default Sans Serif Font of the device is not _Roboto_ now the custom font of the device (e.g. _Choco cooky_ or _Cool Jazz_) is used instead of the new _Roboto_ fonts which were introduced with Material Design. Please note that using the custom font only works on API 14 or higher as the `Bitmap.sameAs()` method requires API 12 or higher. Honeycomb support (or in other words checking for the Droid font) was not added as there are nearly no devices running that platform anymore. 
Also the README was corrected regarding the incorrect statement that lineSpacing is being set automatically. 
